### PR TITLE
ci: auto GitHub releases via changesets action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,15 +41,13 @@ jobs:
       - name: Build Package
         run: pnpm build
 
-      - name: Create Release Pull Request
+      - name: Create Release Pull Request or Publish
         id: changesets
         uses: changesets/action@v1
+        with:
+          publish: pnpm changeset publish --provenance
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Publish to npm
-        if: steps.changesets.outputs.hasChangesets == 'false'
-        run: pnpm changeset publish --provenance
 
   release-next:
     if: github.ref == 'refs/heads/next'


### PR DESCRIPTION
## Summary
- Use `publish` parameter in `changesets/action` instead of a separate publish step
- This enables automatic GitHub Release creation when publishing to npm

## Test plan
- [ ] Merge a "Version Packages" PR and verify the GitHub Release is created automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)